### PR TITLE
Feature/specify ratio ss ds pairs

### DIFF
--- a/lrbenchmark/transformers.py
+++ b/lrbenchmark/transformers.py
@@ -19,14 +19,17 @@ class DummyTransformer(sklearn.base.TransformerMixin):
         return X
 
 
-def pair_absdiff_transform(X: np.ndarray, y: np.ndarray, seed: Optional[int] = None) -> XYType:
+def pair_absdiff_transform(X: np.ndarray,
+                           y: np.ndarray,
+                           ratio_limit: Optional[int] = None,
+                           seed: Optional[int] = None) -> XYType:
     """
     Transforms a basic X y dataset into same source and different source pairs and returns
     an X y dataset where the X is the absolute difference between the two pairs.
 
     Note that this method is different from sklearn TransformerMixin because it also transforms y.
     """
-    pairing = InstancePairing(different_source_limit='balanced', seed=seed)
+    pairing = InstancePairing(ratio_limit=ratio_limit, seed=seed)
     transformer = AbsDiffTransformer()
     X_pairs, y_pairs = pairing.transform(X, y)
     return transformer.transform(X_pairs), y_pairs

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ joblib==1.1.0
     # via scikit-learn
 kiwisolver==1.4.0
     # via matplotlib
-lir==0.1.9
+lir==0.1.11
     # via LRbenchmark (setup.py)
 matplotlib==3.5.1
     # via

--- a/run.py
+++ b/run.py
@@ -42,8 +42,10 @@ def evaluate(dataset: Dataset,
     for idx in tqdm(range(repeats), desc=', '.join(map(str, selected_params.values()))):
         for (X_train, y_train), (X_test, y_test) in dataset.get_splits(seed=idx):
             if dataset.is_commonsource:
-                X_train, y_train = pair_absdiff_transform(X_train, y_train, seed=idx)
-                X_test, y_test = pair_absdiff_transform(X_test, y_test, seed=idx)
+                X_train, y_train = pair_absdiff_transform(X_train, y_train,
+                                                          ratio_limit=50, seed=idx)
+                X_test, y_test = pair_absdiff_transform(X_test, y_test,
+                                                        ratio_limit=1, seed=idx)
 
             calibrated_scorer.fit(X_train, y_train)
             test_lrs.append(calibrated_scorer.predict_lr(X_test))


### PR DESCRIPTION
Specify ratio ds/ss pairs for the train set. Now set to 50, i.e. 50 times more different source pairs compared to same source pairs. For test set, ratio=1.