### PR TITLE
Add GitHub Action for release on publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: fbda
+        password: ${{ secrets.PYPI_FBDA_PASSWORD }}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ dependencies = (
 
 setup(
     name='lrbenchmark',
-    version='0.0',
+    version='0.1',
     author='Netherlands Forensics Institute',
     packages=find_packages(),
     install_requires=dependencies,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = (
 
 
 setup(
-    name='LRbenchmark',
+    name='lrbenchmark',
     version='0.0',
     author='Netherlands Forensics Institute',
     packages=find_packages(),


### PR DESCRIPTION
Action file mostly as it was suggested by GitHub, only changed the secret to be used for upload (which we should change, but not in this PR). Also aligned the package name in setup.py with the package name on import.

Seeing the action file, we'd need to make a release in GitHub to trigger the push to PyPI, that seems fine for now to me.