### PR TITLE
Omit selected_params kwarg from evaluation function call

### DIFF
--- a/lrbenchmark/evaluation.py
+++ b/lrbenchmark/evaluation.py
@@ -118,7 +118,7 @@ class Setup:
         for name, value in param_set.items():
             param_values[name] = value.value
 
-        result = self._evaluate(**param_values, selected_params=param_set)
+        result = self._evaluate(**param_values)
         return param_set, param_values, result
 
     def run_experiments(self, experiments: Union[List[Dict[str, Any]], Dict[str, Any]], default_values=None):


### PR DESCRIPTION
As discussed IRL, passing `selected_params` can be quite useful—it informs the evaluation function which of the variable parameters have been filled with what value—but it puts a complicated requirement on the evaluation function: define a `selected_params` function whether you need it or not.

In trying to use a `Setup` object to specify both constant and variable parameters, this required keyword argument was in the way, the function being experimented with had no use for it. As both the variable parameters and the complete set of arguments to the evaluation function are provided to the caller of `run_experiment` (and therefor also to `run_full_grid` and friends), a user of lrbenchmark can still get at that information as part of the use of `Setup`, along these lines:

```python
def my_pipeline(model, dataset, third_parameter=42):
    return model.apply(dataset)

setup = Setup(my_pipeline)
setup.parameter('dataset', my_dataset)

for variables, arguments, result in setup.run_full_grid({'model': [SimpleModel(), ComplexModel()]}):
    print(f'result for variable selection: {variables}: {result}')
```

A more complicated result from the evaluation function would be passed through verbatim, so there'd be no real harm there.