### PR TITLE
Take measurement and source ids into account when splitting trace/ref

### DIFF
--- a/config/data/asr.yaml
+++ b/config/data/asr.yaml
@@ -7,6 +7,9 @@ dataset:
     beller_fluistert:
       - nee
       - kort
+    languageID:
+      - 7
+      - 9
   trace_properties:
     auto: ja
     duration: 30

--- a/lrbenchmark.yaml
+++ b/lrbenchmark.yaml
@@ -2,7 +2,7 @@ experiment:
   repeats: 1
   pairing:
     - name: cartesian
-  distinguish_trace_reference: True
+  pair_should_have_trace_and_reference_measurements: True
   scorer:
     - name: precalculated_asr
 #    - name: logit

--- a/lrbenchmark.yaml
+++ b/lrbenchmark.yaml
@@ -2,7 +2,7 @@ experiment:
   repeats: 1
   pairing:
     - name: cartesian
-  pair_should_have_trace_and_reference_measurements: True
+  filter_on_trace_reference_properties: True
   scorer:
     - name: precalculated_asr
 #    - name: logit

--- a/lrbenchmark/data/dataset.py
+++ b/lrbenchmark/data/dataset.py
@@ -83,7 +83,7 @@ class Dataset(ABC):
     def get_pairs(self,
                   seed: Optional[int] = None,
                   pairing_function: BasePairing = CartesianPairing(),
-                  distinguish_trace_reference: Optional[bool] = False) -> List[MeasurementPair]:
+                  pair_should_have_trace_and_reference_measurements: Optional[bool] = False) -> List[MeasurementPair]:
         """
         Transforms a dataset into same source and different source pairs and
         returns two arrays of X_pairs and y_pairs where the X_pairs are by
@@ -92,8 +92,7 @@ class Dataset(ABC):
         Note that this method is different from sklearn TransformerMixin
         because it also transforms y.
         """
-        return pairing_function.transform(self.measurements, seed=seed,
-                                          distinguish_trace_reference=distinguish_trace_reference)
+        return pairing_function.transform(self.measurements, seed, pair_should_have_trace_and_reference_measurements)
 
 
 class XTCDataset(Dataset):

--- a/lrbenchmark/data/dataset.py
+++ b/lrbenchmark/data/dataset.py
@@ -103,8 +103,8 @@ class XTCDataset(Dataset):
 
         with open(self.measurements_path, "r") as f:
             reader = csv.DictReader(f)
-            measurements = [Measurement(source=Source(id=int(row['batchnumber']), extra={}),
-                                        extra={'Repeat': int(row['measurement'])},
+            measurements = [Measurement(source=Source(id=int(row['batchnumber']), extra={}), id=int(row['measurement']),
+                                        extra={},
                                         value=np.array(list(map(float, row.values()))[2:])) for row in reader]
         self.measurements = measurements
 
@@ -177,10 +177,11 @@ class ASRDataset(Dataset):
             filename_a = header_measurement_data[i]
             source_id_a, recording_id_a, duration = self.get_ids_and_duration_from_filename(filename_a)
             info_a = recording_data.get(filename_a.replace('_' + str(duration) + 's', ''))
+            is_like_reference = complies_with_filter_requirements(self.reference_properties, info_a or {},
+                                                                  {'duration': duration})
+            is_like_trace = complies_with_filter_requirements(self.trace_properties, info_a or {},
+                                                              {'duration': duration})
             if info_a and complies_with_filter_requirements(self.source_filter, info_a, {'duration': duration}):
-                is_like_reference = complies_with_filter_requirements(self.reference_properties, info_a,
-                                                                      {'duration': duration})
-                is_like_trace = complies_with_filter_requirements(self.trace_properties, info_a, {'duration': duration})
                 measurements.append(Measurement(
                                 Source(id=source_id_a, extra={'sex': info_a['sex'], 'age': info_a['beller_leeftijd']}),
                                 id=recording_id_a,
@@ -188,9 +189,6 @@ class ASRDataset(Dataset):
                                 extra={'filename': filename_a, 'net_duration': float(info_a['net duration']),
                                        'actual_duration': duration, 'auto': info_a['auto']}))
             elif source_id_a.lower() in ['case', 'zaken', 'zaak']:
-                is_like_reference = complies_with_filter_requirements(self.reference_properties, {},
-                                                                      {'duration': duration})
-                is_like_trace = complies_with_filter_requirements(self.trace_properties, {}, {'duration': duration})
                 measurements.append(Measurement(Source(id=source_id_a, extra={}), id=recording_id_a,
                                                 is_like_reference=is_like_reference, is_like_trace=is_like_trace,
                                                 extra={'filename': filename_a, 'actual_duration': duration}))

--- a/lrbenchmark/data/dataset.py
+++ b/lrbenchmark/data/dataset.py
@@ -83,7 +83,7 @@ class Dataset(ABC):
     def get_pairs(self,
                   seed: Optional[int] = None,
                   pairing_function: BasePairing = CartesianPairing(),
-                  pair_should_have_trace_and_reference_measurements: Optional[bool] = False) -> List[MeasurementPair]:
+                  filter_on_trace_reference_properties: Optional[bool] = False) -> List[MeasurementPair]:
         """
         Transforms a dataset into same source and different source pairs and
         returns two arrays of X_pairs and y_pairs where the X_pairs are by
@@ -92,7 +92,7 @@ class Dataset(ABC):
         Note that this method is different from sklearn TransformerMixin
         because it also transforms y.
         """
-        return pairing_function.transform(self.measurements, seed, pair_should_have_trace_and_reference_measurements)
+        return pairing_function.transform(self.measurements, seed, filter_on_trace_reference_properties)
 
 
 class XTCDataset(Dataset):

--- a/lrbenchmark/data/models.py
+++ b/lrbenchmark/data/models.py
@@ -24,12 +24,15 @@ class Measurement:
 
     :param source: the source of the measurement
     :param extra: additional metadata related to the measurement
+    :param id: the identifier of the measurement
     :param is_like_reference: indication of whether the measurement is similar to reference measurements
     :param is_like_trace: indication of whether the measurement is similar to trace measurements
     :param value: the value of the measurement
     """
+
     source: Source
     extra: Mapping[str, Any]
+    id: Optional[Union[int, str]] = None
     is_like_reference: Optional[bool] = None
     is_like_trace: Optional[bool] = None
     value: Optional[Any] = None

--- a/lrbenchmark/pairing.py
+++ b/lrbenchmark/pairing.py
@@ -6,7 +6,7 @@ from typing import List, Iterable, Optional
 import sklearn.base
 
 from lrbenchmark.data.models import Measurement, MeasurementPair
-from lrbenchmark.utils import filter_pairs_on_trace_and_reference_similarity
+from lrbenchmark.utils import apply_filter_on_trace_reference_properties
 
 
 class BasePairing(sklearn.base.TransformerMixin, ABC):
@@ -18,7 +18,7 @@ class BasePairing(sklearn.base.TransformerMixin, ABC):
     def transform(self,
                   measurements: Iterable[Measurement],
                   seed: Optional[int] = None,
-                  pair_should_have_trace_and_reference_measurements: Optional[bool] = False) -> List[MeasurementPair]:
+                  filter_on_trace_reference_properties: Optional[bool] = False) -> List[MeasurementPair]:
         raise NotImplementedError
 
 
@@ -40,10 +40,10 @@ class CartesianPairing(BasePairing):
     def transform(self,
                   measurements: Iterable[Measurement],
                   seed: Optional[int] = None,
-                  pair_should_have_trace_and_reference_measurements: Optional[bool] = False) -> List[MeasurementPair]:
+                  filter_on_trace_reference_properties: Optional[bool] = False) -> List[MeasurementPair]:
         all_pairs = [MeasurementPair(*mp) for mp in itertools.combinations(measurements, 2)]
-        if pair_should_have_trace_and_reference_measurements:
-            all_pairs = filter_pairs_on_trace_and_reference_similarity(all_pairs)
+        if filter_on_trace_reference_properties:
+            all_pairs = apply_filter_on_trace_reference_properties(all_pairs)
         return all_pairs
 
 
@@ -58,11 +58,11 @@ class BalancedPairing(BasePairing):
     def transform(self,
                   measurements: Iterable[Measurement],
                   seed: Optional[int] = None,
-                  pair_should_have_trace_and_reference_measurements: Optional[bool] = False) -> List[MeasurementPair]:
+                  filter_on_trace_reference_properties: Optional[bool] = False) -> List[MeasurementPair]:
         random.seed(seed)
         all_pairs = [MeasurementPair(*mp) for mp in itertools.combinations(measurements, 2)]
-        if pair_should_have_trace_and_reference_measurements:
-            all_pairs = filter_pairs_on_trace_and_reference_similarity(all_pairs)
+        if filter_on_trace_reference_properties:
+            all_pairs = apply_filter_on_trace_reference_properties(all_pairs)
         same_source_pairs = [a for a in all_pairs if a.is_same_source]
         different_source_pairs = [a for a in all_pairs if not a.is_same_source]
         n_pairs = min(len(same_source_pairs), len(different_source_pairs))

--- a/lrbenchmark/pairing.py
+++ b/lrbenchmark/pairing.py
@@ -6,7 +6,7 @@ from typing import List, Iterable, Optional
 import sklearn.base
 
 from lrbenchmark.data.models import Measurement, MeasurementPair
-from lrbenchmark.utils import filter_pairs_on_trace_reference
+from lrbenchmark.utils import filter_pairs_on_trace_and_reference_similarity
 
 
 class BasePairing(sklearn.base.TransformerMixin, ABC):
@@ -43,7 +43,7 @@ class CartesianPairing(BasePairing):
                   distinguish_trace_reference: Optional[bool] = False) -> List[MeasurementPair]:
         all_pairs = [MeasurementPair(*mp) for mp in itertools.combinations(measurements, 2)]
         if distinguish_trace_reference:
-            all_pairs = filter_pairs_on_trace_reference(all_pairs)
+            all_pairs = filter_pairs_on_trace_and_reference_similarity(all_pairs)
         return all_pairs
 
 
@@ -62,7 +62,7 @@ class BalancedPairing(BasePairing):
         random.seed(seed)
         all_pairs = [MeasurementPair(*mp) for mp in itertools.combinations(measurements, 2)]
         if distinguish_trace_reference:
-            all_pairs = filter_pairs_on_trace_reference(all_pairs)
+            all_pairs = filter_pairs_on_trace_and_reference_similarity(all_pairs)
         same_source_pairs = [a for a in all_pairs if a.is_same_source]
         different_source_pairs = [a for a in all_pairs if not a.is_same_source]
         n_pairs = min(len(same_source_pairs), len(different_source_pairs))

--- a/lrbenchmark/pairing.py
+++ b/lrbenchmark/pairing.py
@@ -18,7 +18,7 @@ class BasePairing(sklearn.base.TransformerMixin, ABC):
     def transform(self,
                   measurements: Iterable[Measurement],
                   seed: Optional[int] = None,
-                  distinguish_trace_reference: Optional[bool] = False) -> List[MeasurementPair]:
+                  pair_should_have_trace_and_reference_measurements: Optional[bool] = False) -> List[MeasurementPair]:
         raise NotImplementedError
 
 
@@ -30,8 +30,8 @@ class CartesianPairing(BasePairing):
     By default, the list of MeasurementPair contains all possible pairs of Measurement, except the combination
     of a Measurement with itself. Pairs are considered symmetric, so pairing of measurements [a,b,c] will return
     a-b, a-c, b-c but not also b-a.
-    It is possible to `distinguish_trace_reference`, meaning only measurement pairs will be created of which one
-    measurement is similar to the reference and the other measurement is similar to the trace.
+    It is possible to `pair_should_have_trace_and_reference_measurements`, meaning only measurement pairs will be
+    created of which one measurement is similar to the reference and the other measurement is similar to the trace.
     """
 
     def fit(self, measurements: Iterable[Measurement]):
@@ -40,9 +40,9 @@ class CartesianPairing(BasePairing):
     def transform(self,
                   measurements: Iterable[Measurement],
                   seed: Optional[int] = None,
-                  distinguish_trace_reference: Optional[bool] = False) -> List[MeasurementPair]:
+                  pair_should_have_trace_and_reference_measurements: Optional[bool] = False) -> List[MeasurementPair]:
         all_pairs = [MeasurementPair(*mp) for mp in itertools.combinations(measurements, 2)]
-        if distinguish_trace_reference:
+        if pair_should_have_trace_and_reference_measurements:
             all_pairs = filter_pairs_on_trace_and_reference_similarity(all_pairs)
         return all_pairs
 
@@ -58,10 +58,10 @@ class BalancedPairing(BasePairing):
     def transform(self,
                   measurements: Iterable[Measurement],
                   seed: Optional[int] = None,
-                  distinguish_trace_reference: Optional[bool] = False) -> List[MeasurementPair]:
+                  pair_should_have_trace_and_reference_measurements: Optional[bool] = False) -> List[MeasurementPair]:
         random.seed(seed)
         all_pairs = [MeasurementPair(*mp) for mp in itertools.combinations(measurements, 2)]
-        if distinguish_trace_reference:
+        if pair_should_have_trace_and_reference_measurements:
             all_pairs = filter_pairs_on_trace_and_reference_similarity(all_pairs)
         same_source_pairs = [a for a in all_pairs if a.is_same_source]
         different_source_pairs = [a for a in all_pairs if not a.is_same_source]

--- a/lrbenchmark/utils.py
+++ b/lrbenchmark/utils.py
@@ -31,13 +31,14 @@ def get_experiment_description(selected_params: Optional[Dict[str, Any]]) -> str
         return "defaults"
 
 
-def filter_pairs_on_trace_reference(measurement_pairs: Iterable[MeasurementPair]) -> Iterable[MeasurementPair]:
+def filter_pairs_on_trace_and_reference_similarity(measurement_pairs: Iterable[MeasurementPair]) \
+        -> Iterable[MeasurementPair]:
     """
     Filter measurement pairs on two conditions:
     - the pair must consist of one 'trace_like' measurement and one 'reference_like' measurement
-    - the source id's of the two measurements must differ or the id's of the measurements must differ. We also check
-    the source id because it may occur that multiple sources have the same measurement id's (for instance when
-    measurement id's are counted from 1 for every source).
+    - the source ids of the two measurements must differ or the id's of the measurements must differ. The two
+    measurements in the pair cannot just be different variants of the same measurement. We check this by requiring
+    either the source id or measurement id to be different.
     """
     return [mp for mp in measurement_pairs if
             ((mp.measurement_a.is_like_reference and mp.measurement_b.is_like_trace) or
@@ -45,18 +46,18 @@ def filter_pairs_on_trace_reference(measurement_pairs: Iterable[MeasurementPair]
             (mp.measurement_a.id != mp.measurement_b.id or not mp.is_same_source)]
 
 
-def complies_with_filter_requirements(filter: Dict[str, Any], info: Optional[Dict[str, str]],
+def complies_with_filter_requirements(requirements: Dict[str, Any], info: Optional[Dict[str, str]],
                                       extra: Optional[Dict[str, Any]]) -> bool:
     """
-    Check whether the values in `info` and `extra` match the values in the `filter`. The values in `filter` and `extra`,
-    can be any type (a list of strings, an integer, a boolean), while the values in `info` should be strings. Therefore,
-    parse the `filter` and `extra` values to strings or list of strings.
+    Check whether the values in `info` and `extra` match the values in the `requirements`. The values in `requirements`
+    and `extra`, can be any type (a list of strings, an integer, a boolean), while the values in `info` should be
+    strings. Therefore, parse the `requirements` and `extra` values to strings or list of strings.
     """
     if info is None:
         info = {}
     info.update(**parse_dict_values_to_str(extra)) if extra else info
-    filter = parse_dict_values_to_str(filter)
-    for key, val in filter.items():
+    requirements = parse_dict_values_to_str(requirements)
+    for key, val in requirements.items():
         if isinstance(val, list):
             if not info.get(key) in val:
                 return False

--- a/lrbenchmark/utils.py
+++ b/lrbenchmark/utils.py
@@ -31,7 +31,7 @@ def get_experiment_description(selected_params: Optional[Dict[str, Any]]) -> str
         return "defaults"
 
 
-def filter_pairs_on_trace_and_reference_similarity(measurement_pairs: Iterable[MeasurementPair]) \
+def apply_filter_on_trace_reference_properties(measurement_pairs: Iterable[MeasurementPair]) \
         -> Iterable[MeasurementPair]:
     """
     Filter measurement pairs on two conditions:

--- a/run.py
+++ b/run.py
@@ -50,9 +50,11 @@ def fit_and_evaluate(dataset: Dataset,
         for dataset_train, dataset_validate in dataset.get_splits(seed=idx,
                                                                   **experiment_config['splitting_strategy']):
             train_pairs = dataset_train.get_pairs(pairing_function=pairing_function, seed=idx,
-                                                  distinguish_trace_reference=experiment_config.get('distinguish_trace_reference'))
+                                                  pair_should_have_trace_and_reference_measurements=
+                                                  experiment_config.get('pair_should_have_trace_and_reference_measurements'))
             validate_pairs = dataset_validate.get_pairs(pairing_function=pairing_function, seed=idx,
-                                                        distinguish_trace_reference=experiment_config.get('distinguish_trace_reference'))
+                                                        pair_should_have_trace_and_reference_measurements=
+                                                        experiment_config.get('pair_should_have_trace_and_reference_measurements'))
 
             train_scores = scorer.fit_predict(train_pairs)
             validation_scores = scorer.predict(validate_pairs)
@@ -70,7 +72,8 @@ def fit_and_evaluate(dataset: Dataset,
     # retrain with everything, and apply to the holdout (after the repeat loop)
     if holdout_set:
         holdout_pairs = holdout_set.get_pairs(pairing_function=CartesianPairing(),
-                                              distinguish_trace_reference=experiment_config.get('distinguish_trace_reference'))
+                                              pair_should_have_trace_and_reference_measurements=
+                                              experiment_config.get('pair_should_have_trace_and_reference_measurements'))
         pairs = dataset.get_pairs(pairing_function=pairing_function, seed=idx)
         scores = scorer.fit_predict(pairs)
         holdout_scores = scorer.predict(holdout_pairs)

--- a/run.py
+++ b/run.py
@@ -50,11 +50,11 @@ def fit_and_evaluate(dataset: Dataset,
         for dataset_train, dataset_validate in dataset.get_splits(seed=idx,
                                                                   **experiment_config['splitting_strategy']):
             train_pairs = dataset_train.get_pairs(pairing_function=pairing_function, seed=idx,
-                                                  pair_should_have_trace_and_reference_measurements=
-                                                  experiment_config.get('pair_should_have_trace_and_reference_measurements'))
+                                                  filter_on_trace_reference_properties=
+                                                  experiment_config.get('filter_on_trace_reference_properties'))
             validate_pairs = dataset_validate.get_pairs(pairing_function=pairing_function, seed=idx,
-                                                        pair_should_have_trace_and_reference_measurements=
-                                                        experiment_config.get('pair_should_have_trace_and_reference_measurements'))
+                                                        filter_on_trace_reference_properties=
+                                                        experiment_config.get('filter_on_trace_reference_properties'))
 
             train_scores = scorer.fit_predict(train_pairs)
             validation_scores = scorer.predict(validate_pairs)
@@ -72,8 +72,8 @@ def fit_and_evaluate(dataset: Dataset,
     # retrain with everything, and apply to the holdout (after the repeat loop)
     if holdout_set:
         holdout_pairs = holdout_set.get_pairs(pairing_function=CartesianPairing(),
-                                              pair_should_have_trace_and_reference_measurements=
-                                              experiment_config.get('pair_should_have_trace_and_reference_measurements'))
+                                              filter_on_trace_reference_properties=
+                                              experiment_config.get('filter_on_trace_reference_properties'))
         pairs = dataset.get_pairs(pairing_function=pairing_function, seed=idx)
         scores = scorer.fit_predict(pairs)
         holdout_scores = scorer.predict(holdout_pairs)

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -5,7 +5,8 @@ from lrbenchmark.pairing import CartesianPairing
 def test_split_by_reference(measurements, measurements_set2):
     dataset = Dataset(measurements=measurements + measurements_set2)
     pairing_function = CartesianPairing()
-    pairs = dataset.get_pairs(pairing_function=pairing_function, seed=0, distinguish_trace_reference=True)
+    pairs = dataset.get_pairs(pairing_function=pairing_function, seed=0,
+                              pair_should_have_trace_and_reference_measurements=True)
     for pair in pairs:
         assert (pair.measurement_a.is_like_reference and pair.measurement_b.is_like_trace) or (
                 pair.measurement_a.is_like_trace and pair.measurement_b.is_like_reference)

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -5,8 +5,7 @@ from lrbenchmark.pairing import CartesianPairing
 def test_split_by_reference(measurements, measurements_set2):
     dataset = Dataset(measurements=measurements + measurements_set2)
     pairing_function = CartesianPairing()
-    pairs = dataset.get_pairs(pairing_function=pairing_function, seed=0,
-                              pair_should_have_trace_and_reference_measurements=True)
+    pairs = dataset.get_pairs(pairing_function=pairing_function, seed=0, filter_on_trace_reference_properties=True)
     for pair in pairs:
         assert (pair.measurement_a.is_like_reference and pair.measurement_b.is_like_trace) or (
                 pair.measurement_a.is_like_trace and pair.measurement_b.is_like_reference)


### PR DESCRIPTION
Also correctly parse filter and info values so we can filter on for instance language id.